### PR TITLE
Implement Platform API

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,9 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "update-entity-type": "curl https://raw.githubusercontent.com/Koreatech-Mongle/chameleon-platform/develop/src/types/chameleon-platform.entitydata.d.ts -o src/types/chameleon-client.entitydata.d.ts",
+    "update-enum-type": "curl https://raw.githubusercontent.com/Koreatech-Mongle/chameleon-platform/develop/src/types/chameleon-platform.enum.ts -o src/types/chameleon-client.enum.ts"
   },
   "eslintConfig": {
     "extends": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,13 +33,13 @@ export default function App() {
 
     useEffect(() => {
         let message = lastJsonMessage as any;
-        if (lastJsonMessage && message.msg === WSMessageType.Ready) {
-            sendJsonMessage({msg: 'path', path: window.location.pathname});
+        if (lastJsonMessage && message.msg === WSMessageType.READY) {
+            sendJsonMessage({msg: WSMessageType.PATH, path: window.location.pathname});
         }
     }, [lastJsonMessage]);
 
     useEffect(() => {
-        sendJsonMessage({msg: 'path', path: window.location.pathname});
+        sendJsonMessage({msg: WSMessageType.PATH, path: window.location.pathname});
     }, [window.location.pathname]);
 
     return (

--- a/src/components/layout/Description.tsx
+++ b/src/components/layout/Description.tsx
@@ -32,7 +32,7 @@ export default function Description({uniqueName}: DescriptionProps) {
 
         (async function get() {
             try {
-                const response = await instance.get(`/model/info?uniqueName=${uniqueName}`,{
+                const response = await instance.get(`/model/legacy-info?uniqueName=${uniqueName}`,{
                     timeout: 5000,
                     withCredentials: true,
                     headers: {

--- a/src/pages/model/board/Model.tsx
+++ b/src/pages/model/board/Model.tsx
@@ -38,7 +38,7 @@ export default function Model() {
 
     (async function get() {
       try {
-        const response = await instance.get(`/model/list`, {
+        const response = await instance.get(`/model/legacy-list`, {
           timeout: 5000,
           withCredentials: true,
           headers: {

--- a/src/platform/PlatformAPI.ts
+++ b/src/platform/PlatformAPI.ts
@@ -43,15 +43,20 @@ export class PlatformAPI {
         return response?.data as ModelEntityData;
     }
 
-    public static async signIn(email: string, password: string) {
-        await this.instance.post('/auth/sign-in', {email, password}, this.defaultConfig);
+    // TODO: 반환 형 타입 지정
+    public static async signIn(email: string, password: string): Promise<any> {
+        const response = await this.instance.post('/auth/sign-in', {email, password}, this.defaultConfig);
+        return response?.data;
     }
 
-    public static async signUp(email: string, password: string, username: string) {
-        await this.instance.post('/auth/sign-up', {email, password, username}, this.defaultConfig);
+    // TODO: 반환 형 타입 지정
+    public static async signUp(email: string, password: string, username: string): Promise<any> {
+        const response = await this.instance.post('/auth/sign-up', {email, password, username}, this.defaultConfig);
+        return response?.data;
     }
 
     public static async payment(amount: number) {
+        // TODO: 반환 형 명시
         await this.instance.post('/payment', {amount}, this.defaultConfig);
     }
 }

--- a/src/platform/PlatformAPI.ts
+++ b/src/platform/PlatformAPI.ts
@@ -1,0 +1,57 @@
+import axios from "axios";
+import {ModelEntityData, RegionEntityData, UserEntityData} from "../types/chameleon-client.entitydata";
+import {ModelUploadData} from "../types/chameleon-client";
+
+export class PlatformAPI {
+    private static readonly instance = axios.create({
+        baseURL: '/api/',
+        withCredentials: true,
+        timeout: 1000
+    });
+    private static readonly defaultConfig = {headers: {'Content-Type': 'application/json'}};
+
+    public static async uploadModel(uploadData: ModelUploadData): Promise<any> {
+        const formData = new FormData();
+        Object.entries(uploadData).forEach(([name, value]) => {
+            formData.append(name, value);
+        });
+        const response = await this.instance.post('/model/upload', formData, {
+            ...this.defaultConfig, timeout: 0, headers: {
+                'Content-Type': 'multipart/form-data',
+            }
+        });
+        return response?.data;
+    }
+
+    public static async getModelList(): Promise<ModelEntityData[]> {
+        const response = await this.instance.get('/model/list', this.defaultConfig);
+        return response?.data as ModelEntityData[];
+    }
+
+    public static async getUserInfo(): Promise<UserEntityData> {
+        const response = await this.instance.get('/user/info', this.defaultConfig);
+        return response?.data as UserEntityData;
+    }
+
+    public static async getRegionList(): Promise<RegionEntityData[]> {
+        const response = await this.instance.get('/region/list', this.defaultConfig);
+        return response?.data as RegionEntityData[];
+    }
+
+    public static async getModelInfo(uniqueName: string): Promise<ModelEntityData> {
+        const response = await this.instance.get('/model/info', {...this.defaultConfig, params: {uniqueName}});
+        return response?.data as ModelEntityData;
+    }
+
+    public static async signIn(email: string, password: string) {
+        await this.instance.post('/auth/sign-in', {email, password}, this.defaultConfig);
+    }
+
+    public static async signUp(email: string, password: string, username: string) {
+        await this.instance.post('/auth/sign-up', {email, password, username}, this.defaultConfig);
+    }
+
+    public static async payment(amount: number) {
+        await this.instance.post('/payment', {amount}, this.defaultConfig);
+    }
+}

--- a/src/platform/PlatformAPI.ts
+++ b/src/platform/PlatformAPI.ts
@@ -55,8 +55,8 @@ export class PlatformAPI {
         return response?.data;
     }
 
+    // TODO: 반환 형 명시
     public static async payment(amount: number) {
-        // TODO: 반환 형 명시
         await this.instance.post('/payment', {amount}, this.defaultConfig);
     }
 }

--- a/src/service/authentication/UserInfoService.ts
+++ b/src/service/authentication/UserInfoService.ts
@@ -17,7 +17,7 @@ export default function useGetUserInfo() {
 
     (async function get() {
       try {
-        const response = await instance.get(`/auth/info`, {
+        const response = await instance.get(`/auth/legacy-info`, {
           timeout: 5000,
           withCredentials: true,
           headers: {

--- a/src/types/chameleon-client.d.ts
+++ b/src/types/chameleon-client.d.ts
@@ -44,4 +44,14 @@ type DownloadButtonProps = {
     filename: string;
 }
 
+
+export type ModelUploadData = {
+    modelName: string;
+    inputType: string;
+    outputType: string;
+    regionName: string;
+    file: File;
+    description: string
+}
+
 export type {Parameter, HeaderData, DefaultButtonData, SubmitButtonData, WebSocketData, DownloadButtonProps};

--- a/src/types/chameleon-client.entitydata.d.ts
+++ b/src/types/chameleon-client.entitydata.d.ts
@@ -1,0 +1,62 @@
+export interface HistoryEntityData {
+    id: number;
+    createdTime: Date;
+    updatedTime: Date;
+    status: string;
+    inputPath: string;
+    inputInfo: any;
+    outputPath: string;
+    outputInfo: any;
+    description: string;
+    executor: UserEntityData;
+    model: ModelEntityData;
+    startedTime: Date;
+    endedTime: Date;
+    parameters: any;
+    terminal: string;
+}
+
+export interface ImageEntityData {
+    id: number;
+    repository: string;
+    tag: string;
+    path: string;
+    uniqueId: string;
+    region: RegionEntityData;
+}
+
+export interface ModelEntityData {
+    id: number;
+    createdTime: Date;
+    updatedTime: Date;
+    uniqueName: string;
+    name: string;
+    description: string;
+    register: UserEntityData;
+    image: ImageEntityData;
+    cacheSize: number;
+    inputType: string;
+    outputType: string;
+    parameters: any;
+    config: any;
+}
+
+export interface RegionEntityData {
+    id: number;
+    name: string;
+    host: string;
+    port: number;
+    cacheSize: number;
+}
+
+export interface UserEntityData {
+    id: number;
+    email: string;
+    username: string;
+}
+
+export interface WalletEntityData {
+    id: number;
+    point: number;
+    user: UserEntityData;
+}

--- a/src/types/chameleon-client.enum.ts
+++ b/src/types/chameleon-client.enum.ts
@@ -1,10 +1,37 @@
+export enum HistoryStatus {
+    CACHED = 'cached',
+    INITIALIZING = 'initializing',
+    RUNNING = 'running',
+    ERROR = 'error',
+    FINISHED = 'finished',
+}
+
 export enum WSMessageType {
-    Ready = 'Ready',
-    Path = 'Path',
-    TerminalResize = 'TerminalResize',
-    Terminal = 'Terminal',
-    UpdateModel = 'UpdateModel',
-    UpdateModels = 'UpdateModels',
-    UpdateHistory = 'UpdateHistory',
-    UpdateHistories = 'UpdateHistories'
+    READY = 'Ready',
+    PATH = 'Path',
+    TERMINAL_RESIZE = 'TerminalResize',
+    TERMINAL = 'Terminal',
+    UPDATE_MODEL = 'UpdateModel',
+    UPDATE_MODELS = 'UpdateModels',
+    UPDATE_HISTORY = 'UpdateHistory',
+    UPDATE_HISTORIES = 'UpdateHistories'
+}
+
+export enum SocketMessageType {
+    HELLO = 'Hello',
+    LAUNCH = 'Launch',
+    FILE_WAIT = 'FileWait',
+    FILE_RECEIVE_END = 'FileReceiveEnd',
+    TERMINAL = 'Terminal',
+    TERMINAL_RESIZE = 'TerminalResize',
+    PROCESS_END = 'ProcessEnd',
+    FILE = 'File',
+    REQUEST_FILE = 'RequestFile',
+    WAIT_RECEIVE = 'WaitReceive',
+    LAUNCH_MODEL = 'LaunchModel'
+}
+
+export enum SocketReceiveMode {
+    JSON,
+    FILE
 }


### PR DESCRIPTION
API 사용간 사용하는 코드의 통일성을 위해서, EntityData 자료형을 도입

기존 GyuBa가 만들었던 API 구조보다 더 직관적인 형태로 자료 구조를 다듬음

이 과정에서 기존 형태의 결과를 반환하던 아래 API는 
 - `/auth/info` → `/auth/legacy-info`
 - `/model/info` → `/model/legacy-info`
 - `/model/list` → `/model/legacy-list`

현재 legacy 형태로 경로가 바뀌었으며(이 PR에는 우선 기존 구현 결과물들이 작동하도록 legacy path로 경로를 수정해 두었음), 결과적으로 신규 API로 마이그레이션 작업이 필요함 (마이그레이션 완료된 이후에는 legacy API는 삭제 될 예정)

신규 API는 기존 API보다 훨씬 직관적으로 사용할 수 있음. PlatformAPI 클래스에 정의된 함수를 그냥 사용하면
알아서 데이터 형이 맵핑된 객체를 반환하는 방식으로 설계됨

앞으로 API를 추가할 때에는 PlatformAPI 클래스에 정의를 한 뒤 사용하는 방식을 취할 것