### PR TITLE
Add close model description method

### DIFF
--- a/src/components/layout/Description.tsx
+++ b/src/components/layout/Description.tsx
@@ -49,7 +49,7 @@ export default function Description(props: DescriptionProps) {
                         <Link to="/models/execute" state={{}}>
                             <Button className="color-btn text-sm w-full p-1.5" text="start"/>
                         </Link>
-                        <button className="text-gray-500 text-xl rounded-full hover:text-black hover:bg-light-gray"
+                        <button className="text-gray-500 text-2xl rounded-full hover:text-black hover:bg-light-gray"
                                 onClick={() => (setSelectedModel(""))}><MdOutlineCancel/></button>
                     </div>
                 </div>

--- a/src/components/layout/Description.tsx
+++ b/src/components/layout/Description.tsx
@@ -6,11 +6,8 @@ import Button from "../button/Button";
 import {PlatformAPI} from "../../platform/PlatformAPI";
 import {ModelEntityData} from "../../types/chameleon-client.entitydata";
 import {MdOutlineCancel} from "react-icons/md";
+import {DescriptionProps} from "../../types/chameleon-client.entitydata";
 
-interface DescriptionProps {
-    uniqueName: string;
-    setSelectedModel: React.Dispatch<React.SetStateAction<string>>
-}
 
 export default function Description(props: DescriptionProps) {
     const {uniqueName, setSelectedModel} = props;

--- a/src/components/layout/Description.tsx
+++ b/src/components/layout/Description.tsx
@@ -8,9 +8,11 @@ import {ModelEntityData} from "../../types/chameleon-client.entitydata";
 
 interface DescriptionProps {
     uniqueName: string;
+    setSelectedModel: React.Dispatch<React.SetStateAction<string>>
 }
 
-export default function Description({uniqueName}: DescriptionProps, {setSelectedModel} : React.Dispatch<React.SetStateAction<string>>) {
+export default function Description(props: DescriptionProps) {
+    const {uniqueName, setSelectedModel} = props;
     const [modelData, setModelData] = useState<ModelEntityData>();
 
     useEffect(() => {
@@ -45,8 +47,8 @@ export default function Description({uniqueName}: DescriptionProps, {setSelected
                     <div className="flex gap-2">
                         <Link to="/models/execute" state={{}}>
                             <Button className="color-btn text-sm w-full p-1.5" text="start"/>
-                            <button className="color-btn text-sm w-full p-1.5" onClick={() => (setSelectedModel(""))}> x </button>
                         </Link>
+                        <button className="color-btn text-sm w-full p-1.5" onClick={() => (setSelectedModel(""))}> x </button>
                     </div>
                 </div>
                 <div className="mt-8 overflow-auto overflow-scroll max-h-screen">

--- a/src/components/layout/Description.tsx
+++ b/src/components/layout/Description.tsx
@@ -5,6 +5,7 @@ import MDEditor from "@uiw/react-md-editor";
 import Button from "../button/Button";
 import {PlatformAPI} from "../../platform/PlatformAPI";
 import {ModelEntityData} from "../../types/chameleon-client.entitydata";
+import {MdOutlineCancel} from "react-icons/md";
 
 interface DescriptionProps {
     uniqueName: string;
@@ -44,11 +45,12 @@ export default function Description(props: DescriptionProps) {
                 <div
                     className="flex justify-between items-center pb-6 border-b-1 border-gray-300 overflow-auto overflow-scroll max-h-screen">
                     <p className="text-3xl font-extrabold tracking-tight text-slate-900">{modelData?.name}</p>
-                    <div className="flex gap-2">
+                    <div className="flex gap-2 items-center">
                         <Link to="/models/execute" state={{}}>
                             <Button className="color-btn text-sm w-full p-1.5" text="start"/>
                         </Link>
-                        <button className="color-btn text-sm w-full p-1.5" onClick={() => (setSelectedModel(""))}> x </button>
+                        <button className="text-gray-500 text-xl rounded-full hover:text-black hover:bg-light-gray"
+                                onClick={() => (setSelectedModel(""))}><MdOutlineCancel/></button>
                     </div>
                 </div>
                 <div className="mt-8 overflow-auto overflow-scroll max-h-screen">

--- a/src/components/layout/Description.tsx
+++ b/src/components/layout/Description.tsx
@@ -10,7 +10,7 @@ interface DescriptionProps {
     uniqueName: string;
 }
 
-export default function Description({uniqueName}: DescriptionProps) {
+export default function Description({uniqueName}: DescriptionProps, {setSelectedModel} : React.Dispatch<React.SetStateAction<string>>) {
     const [modelData, setModelData] = useState<ModelEntityData>();
 
     useEffect(() => {
@@ -45,6 +45,7 @@ export default function Description({uniqueName}: DescriptionProps) {
                     <div className="flex gap-2">
                         <Link to="/models/execute" state={{}}>
                             <Button className="color-btn text-sm w-full p-1.5" text="start"/>
+                            <button className="color-btn text-sm w-full p-1.5" onClick={() => (setSelectedModel(""))}> x </button>
                         </Link>
                     </div>
                 </div>

--- a/src/pages/model/board/Models.tsx
+++ b/src/pages/model/board/Models.tsx
@@ -175,9 +175,9 @@ export default function Models() {
             </div>
         </div>
         {selectedModel ?
-            <div className="w-2/6 ease-in-out duration-300 translate-x-0"><Description uniqueName={selectedModel}/></div>
+            <div className="w-2/6 ease-in-out duration-300 translate-x-0"><Description uniqueName={selectedModel} setSelectedModel={setSelectedModel}/></div>
             :
-            <div className="w-0 ease-in-out duration-300 translate-x-full hidden"><Description uniqueName={selectedModel}/></div>
+            <div className="w-0 ease-in-out duration-300 translate-x-full hidden"><Description uniqueName={selectedModel}  setSelectedModel={setSelectedModel}/></div>
         }
     </div>
   );

--- a/src/types/chameleon-client.entitydata.d.ts
+++ b/src/types/chameleon-client.entitydata.d.ts
@@ -1,3 +1,5 @@
+import React from "react";
+
 export interface HistoryEntityData {
     id: number;
     createdTime: Date;
@@ -59,4 +61,9 @@ export interface WalletEntityData {
     id: number;
     point: number;
     user: UserEntityData;
+}
+
+export interface DescriptionProps {
+    uniqueName: string;
+    setSelectedModel: React.Dispatch<React.SetStateAction<string>>
 }


### PR DESCRIPTION
## Method
[fix: Description error (navigate to execute, props error)](https://github.com/Koreatech-Mongle/chameleon-client/commit/7d8457f243fddd37448c978de7cdb12445fc6476) 

[feat: button have onClick React.SetStateAction](https://github.com/Koreatech-Mongle/chameleon-client/commit/92096d831f1c1c83feab7ef487c55c4cd4126d3c)
## Description 
- add setStateAction to DescriptionProps
- add button
- add onClick Attribute to close description
